### PR TITLE
API: List method [Tana]

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 actix-cors = "0.7"
 actix-web = "4.9"
 anyhow = "1.0"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 dotenv = "0.15.0"
 directories = "5.0"
 
@@ -17,3 +17,4 @@ url = "^2"
 
 tokio = { version = "1", features = ["full"] }
 futures = "0.3.30"
+serde = { version = "1.0.209", features = ["derive"] }

--- a/src/format/mod.rs
+++ b/src/format/mod.rs
@@ -2,7 +2,7 @@ mod tana;
 pub use tana::*;
 
 mod raw;
-pub use raw::*;
+// pub use raw::*;
 
 use super::{Event, EventType};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,73 +1,12 @@
-use actix_cors::Cors;
-use actix_web::{error, get, web, App, HttpResponse, HttpServer, Responder};
-use anyhow::Result;
-
 mod calendar;
 use calendar::*;
 mod format;
 use format::Format;
-
-struct AppState {
-    cal: Calendar,
-}
-impl AppState {
-    pub fn new(cal: Calendar) -> Self {
-        Self { cal }
-    }
-
-    pub async fn get_events<T: Format>(&self) -> Result<String> {
-        let now = chrono::Local::now();
-        let events = self
-            .cal
-            .get_events(now - chrono::Duration::days(1), now, false)
-            .await?;
-        Ok(events
-            .into_iter()
-            .filter_map(|e| T::format(e))
-            .collect::<Vec<_>>()
-            .join(T::newline()))
-    }
-}
-
-#[get("/")]
-async fn index() -> impl Responder {
-    HttpResponse::Ok().body("Hello world!")
-}
-
-#[get("/raw")]
-async fn raw(data: web::Data<AppState>) -> actix_web::Result<String> {
-    data.get_events::<format::Raw>()
-        .await
-        .map_err(|err| error::ErrorFailedDependency(err.to_string()))
-}
-
-#[get("/tana")]
-async fn tana(data: web::Data<AppState>) -> actix_web::Result<String> {
-    data.get_events::<format::Tana>()
-        .await
-        .map_err(|err| error::ErrorFailedDependency(err.to_string()))
-}
+mod server;
+use server::Server;
 
 #[actix_web::main]
-async fn main() -> std::io::Result<()> {
-    dotenv::dotenv().ok();
-
-    let cal = Calendar::new().await.expect("Failed to create app state");
-    let data = web::Data::new(AppState::new(cal));
-
-    println!("🚀 Server started successfully");
-    HttpServer::new(move || {
-        App::new()
-            .app_data(data.clone())
-            .wrap(
-                Cors::default()
-                    .allowed_origin("https://app.tana.inc")
-                    .allowed_methods(vec!["GET", "POST"]),
-            )
-            .service(index)
-            .service(tana)
-    })
-    .bind(("127.0.0.1", 7117))?
-    .run()
-    .await
+async fn main() -> anyhow::Result<()> {
+    let cal = Calendar::new().await.expect("Failed to create calendar");
+    Server::new("127.0.0.1".to_string(), 7117).run(cal).await
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,10 +1,12 @@
 use actix_cors::Cors;
-use actix_web::{error, get, web, App, HttpResponse, HttpServer, Responder};
+use actix_web::{get, web, App, HttpResponse, HttpServer, Responder};
 
 use super::*;
 
 mod state;
 use state::*;
+mod types;
+use types::*;
 mod tana;
 
 pub struct Server {
@@ -19,9 +21,6 @@ async fn index() -> impl Responder {
 
 #[get("/raw")]
 async fn raw(_: web::Data<State>) -> actix_web::Result<String> {
-    // data.get_events::<format::Raw>()
-    //     .await
-    //     .map_err(|err| error::ErrorFailedDependency(err.to_string()))
     todo!()
 }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,0 +1,52 @@
+use actix_cors::Cors;
+use actix_web::{error, get, web, App, HttpResponse, HttpServer, Responder};
+
+use super::*;
+
+mod state;
+use state::*;
+mod tana;
+
+pub struct Server {
+    ip: String,
+    port: u16,
+}
+
+#[get("/")]
+async fn index() -> impl Responder {
+    HttpResponse::Ok().body("Hello world!")
+}
+
+#[get("/raw")]
+async fn raw(_: web::Data<State>) -> actix_web::Result<String> {
+    // data.get_events::<format::Raw>()
+    //     .await
+    //     .map_err(|err| error::ErrorFailedDependency(err.to_string()))
+    todo!()
+}
+
+impl Server {
+    pub fn new(ip: String, port: u16) -> Self {
+        Self { ip, port }
+    }
+    pub async fn run(self, cal: Calendar) -> anyhow::Result<()> {
+        let state = web::Data::new(State::new(cal));
+
+        println!("🚀 Server started successfully");
+        HttpServer::new(move || {
+            App::new()
+                .app_data(state.clone())
+                .wrap(
+                    Cors::default()
+                        .allowed_origin("https://app.tana.inc")
+                        .allowed_methods(vec!["GET", "POST"]),
+                )
+                .service(index)
+                .configure(tana::config)
+        })
+        .bind((self.ip, self.port))?
+        .run()
+        .await?;
+        Ok(())
+    }
+}

--- a/src/server/state.rs
+++ b/src/server/state.rs
@@ -1,0 +1,32 @@
+use anyhow::Result;
+use chrono::{DateTime, Local, NaiveDate, NaiveTime};
+
+use super::{Calendar, Format};
+
+pub struct State {
+    cal: Calendar,
+}
+impl State {
+    pub fn new(cal: Calendar) -> Self {
+        Self { cal }
+    }
+
+    pub async fn get_events<T: Format>(&self, start: NaiveDate, end: NaiveDate) -> Result<String> {
+        let events = self
+            .cal
+            .get_events(to_datetime(start), to_datetime(end), false)
+            .await?;
+        Ok(events
+            .into_iter()
+            .filter_map(|e| T::format(e))
+            .collect::<Vec<_>>()
+            .join(T::newline()))
+    }
+}
+
+fn to_datetime(date: NaiveDate) -> DateTime<Local> {
+    date.and_time(NaiveTime::from_hms_opt(0, 0, 0).unwrap())
+        .and_local_timezone(Local)
+        .earliest()
+        .expect("Cant convert to local datetime")
+}

--- a/src/server/tana.rs
+++ b/src/server/tana.rs
@@ -1,0 +1,93 @@
+use actix_web::{
+    error::{self, PayloadError},
+    get, web, Result,
+};
+use chrono::{Datelike, Duration, Month, Months, NaiveDate, Utc, Weekday};
+use serde::{Deserialize, Serialize};
+
+use super::{format, State};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+pub enum Occurrence {
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct List {
+    occurence: Occurrence,
+    start: String,
+    #[serde(skip_deserializing)]
+    end: Option<String>,
+}
+impl List {
+    fn extract(&self) -> anyhow::Result<(NaiveDate, NaiveDate)> {
+        let now = Utc::now();
+        let start = match self.occurence {
+            Occurrence::Daily => NaiveDate::parse_from_str(
+                &format!("{} {}", self.start, now.year()),
+                "%a, %b %-d %Y",
+            )?,
+            Occurrence::Weekly => {
+                NaiveDate::from_isoywd_opt(now.year(), extract_number(&self.start)?, Weekday::Sun)
+                    .unwrap()
+            }
+            Occurrence::Monthly => NaiveDate::from_ymd_opt(
+                now.year(),
+                self.start.parse::<Month>()?.number_from_month(),
+                1,
+            )
+            .unwrap(),
+        };
+        Ok((
+            start,
+            match self.occurence {
+                Occurrence::Daily => start + Duration::days(1),
+                Occurrence::Weekly => start + Duration::weeks(1),
+                Occurrence::Monthly => start + Months::new(1),
+            },
+        ))
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Get {
+    cal_id: String,
+    event_id: String,
+}
+
+pub fn config(conf: &mut web::ServiceConfig) {
+    conf.service(web::scope("/tana").service(get).service(list));
+}
+
+#[get("/get/{cal_id}/{event_id}")]
+async fn get(_: web::Data<State>, get: web::Path<Get>) -> Result<String> {
+    println!("{:?}", get);
+    // data.get_events::<format::Tana>()
+    //     .await
+    //     .map_err(|err| error::ErrorFailedDependency(err.to_string()))
+    todo!()
+}
+
+#[get("/list")]
+async fn list(data: web::Data<State>, list: web::Json<List>) -> Result<String> {
+    println!("{:?}", &list);
+    let (start, end) = list.extract().or(Err(error::JsonPayloadError::Payload(
+        PayloadError::EncodingCorrupted,
+    )))?;
+    data.get_events::<format::Tana>(start, end)
+        .await
+        .map_err(|err| error::ErrorFailedDependency(err.to_string()))
+}
+
+fn extract_number(input: &str) -> anyhow::Result<u32> {
+    // Split the string on spaces and look for a numeric part
+    for part in input.split_whitespace() {
+        // Try to parse each part to a number
+        if let Ok(number) = part.parse::<u32>() {
+            return Ok(number);
+        }
+    }
+    anyhow::bail!("Failed to extract number")
+}

--- a/src/server/tana.rs
+++ b/src/server/tana.rs
@@ -1,61 +1,6 @@
-use actix_web::{
-    error::{self, PayloadError},
-    get, web, Result,
-};
-use chrono::{Datelike, Duration, Month, Months, NaiveDate, Utc, Weekday};
-use serde::{Deserialize, Serialize};
+use actix_web::{error, get, web, Result};
 
-use super::{format, State};
-
-#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
-pub enum Occurrence {
-    Daily,
-    Weekly,
-    Monthly,
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct List {
-    occurence: Occurrence,
-    start: String,
-    #[serde(skip_deserializing)]
-    end: Option<String>,
-}
-impl List {
-    fn extract(&self) -> anyhow::Result<(NaiveDate, NaiveDate)> {
-        let now = Utc::now();
-        let start = match self.occurence {
-            Occurrence::Daily => NaiveDate::parse_from_str(
-                &format!("{} {}", self.start, now.year()),
-                "%a, %b %-d %Y",
-            )?,
-            Occurrence::Weekly => {
-                NaiveDate::from_isoywd_opt(now.year(), extract_number(&self.start)?, Weekday::Sun)
-                    .unwrap()
-            }
-            Occurrence::Monthly => NaiveDate::from_ymd_opt(
-                now.year(),
-                self.start.parse::<Month>()?.number_from_month(),
-                1,
-            )
-            .unwrap(),
-        };
-        Ok((
-            start,
-            match self.occurence {
-                Occurrence::Daily => start + Duration::days(1),
-                Occurrence::Weekly => start + Duration::weeks(1),
-                Occurrence::Monthly => start + Months::new(1),
-            },
-        ))
-    }
-}
-
-#[derive(Debug, Serialize, Deserialize, Clone)]
-pub struct Get {
-    cal_id: String,
-    event_id: String,
-}
+use super::{format, Get, List, State};
 
 pub fn config(conf: &mut web::ServiceConfig) {
     conf.service(web::scope("/tana").service(get).service(list));
@@ -64,30 +9,16 @@ pub fn config(conf: &mut web::ServiceConfig) {
 #[get("/get/{cal_id}/{event_id}")]
 async fn get(_: web::Data<State>, get: web::Path<Get>) -> Result<String> {
     println!("{:?}", get);
-    // data.get_events::<format::Tana>()
-    //     .await
-    //     .map_err(|err| error::ErrorFailedDependency(err.to_string()))
     todo!()
 }
 
 #[get("/list")]
 async fn list(data: web::Data<State>, list: web::Json<List>) -> Result<String> {
     println!("{:?}", &list);
-    let (start, end) = list.extract().or(Err(error::JsonPayloadError::Payload(
-        PayloadError::EncodingCorrupted,
-    )))?;
+    let (start, end) = list.extract().ok_or(error::JsonPayloadError::Payload(
+        error::PayloadError::EncodingCorrupted,
+    ))?;
     data.get_events::<format::Tana>(start, end)
         .await
         .map_err(|err| error::ErrorFailedDependency(err.to_string()))
-}
-
-fn extract_number(input: &str) -> anyhow::Result<u32> {
-    // Split the string on spaces and look for a numeric part
-    for part in input.split_whitespace() {
-        // Try to parse each part to a number
-        if let Ok(number) = part.parse::<u32>() {
-            return Ok(number);
-        }
-    }
-    anyhow::bail!("Failed to extract number")
 }

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -1,0 +1,60 @@
+use chrono::{Datelike, Duration, Month, Months, NaiveDate, Utc, Weekday};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize, Clone, Copy)]
+pub enum Occurrence {
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct List {
+    pub occurence: Occurrence,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub year: Option<i32>,
+    pub start: String,
+    #[serde(skip_deserializing)]
+    pub end: Option<String>,
+}
+impl List {
+    pub fn extract(&self) -> Option<(NaiveDate, NaiveDate)> {
+        let year = self.year.unwrap_or(Utc::now().year());
+        let start = match self.occurence {
+            Occurrence::Daily => {
+                NaiveDate::parse_from_str(&format!("{} {}", self.start, year), "%a, %b %-d %Y").ok()
+            }
+            Occurrence::Weekly => {
+                NaiveDate::from_isoywd_opt(year, extract_number(&self.start)?, Weekday::Sun)
+            }
+            Occurrence::Monthly => NaiveDate::from_ymd_opt(
+                year,
+                self.start.parse::<Month>().ok()?.number_from_month(),
+                1,
+            ),
+        }?;
+        Some((
+            start,
+            match self.occurence {
+                Occurrence::Daily => start + Duration::days(1),
+                Occurrence::Weekly => start + Duration::weeks(1),
+                Occurrence::Monthly => start + Months::new(1),
+            },
+        ))
+    }
+}
+fn extract_number(input: &str) -> Option<u32> {
+    for part in input.split_whitespace() {
+        // Try to parse each part to a number
+        if let Ok(number) = part.parse::<u32>() {
+            return Some(number);
+        }
+    }
+    None
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Get {
+    pub cal_id: String,
+    pub event_id: String,
+}


### PR DESCRIPTION
## Features
Setup Tana API with Get placeholder.
Finished the initial implementation of List API method.

## Notes
List supports 3 granularities [occurrence], formats shown as examples:
> All three types will use the current year unless specified with the "year" tag shown below.
- Daily: "Thu, Sep 5"
- Weekly: "Week 10"
- Monthly: "September"

## Usage
- URL: `http://example.com/tana/list`
- Payload:
  - occurrence
  - year [optional]
  - start
  - end [optional]

### Example Payloads
```json
{
    "occurence": "Daily",
    "year": 2023,
    "start": "Thu, Sep 5"
}
```
```json
{
    "occurence": "Week",
    "start": "Week 10"
}
```